### PR TITLE
Add native Ollama /api/chat provider (APIType=ollama)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ Copy `env/dist/etc/modules/playerbots_characters.conf.dist` as `env/dist/etc/mod
 
 ### Model Connection Setup
 
-The module supports two API formats, controlled by `PBC.APIType`:
+The module supports three API formats, controlled by `PBC.APIType`:
 
 - **`openai`** (default) — OpenAI-compatible `/chat/completions` endpoint. The module appends `/chat/completions` to `PBC.BaseUrl` and sends the API key via `Authorization: Bearer` header.
 - **`anthropic`** — Anthropic Messages API `/messages` endpoint. The module appends `/messages` to `PBC.BaseUrl` and sends the API key via `x-api-key` header with the `anthropic-version: 2023-06-01` header.
+- **`ollama`** — Ollama native `/api/chat` endpoint. The module appends `/api/chat` to `PBC.BaseUrl` and exposes Ollama-specific controls (`think`, `keep_alive`, `num_ctx`, `num_predict`) that the OpenAI-compatible shim hides. Recommended for local Ollama instances — `think:false` suppresses the reasoning tokens that otherwise dominate latency. See [Ollama (local)](#ollama-local) below.
 
 You need to configure at least `PBC.BaseUrl`, `PBC.Model` and `PBC.ApiKey` before the module can generate responses. The relevant config options are in the **API CONNECTION** and **MODEL PARAMETERS** sections of the config file. After configuring, you can use `.chars api-test` to quickly verify that the connection is working (or `.chars alt-api-test` for the alternative model).
 
@@ -121,17 +122,52 @@ DeepSeek offers a reasonable cost/capabilities compromise and can be considered 
 
 GLM 5.1 handles the required tasks impressively well, though the cost adds up fairly quickly. Expect to spend around $2 per long game session with a full party.
 
+#### Ollama (local)
+
+For a local [Ollama](https://ollama.com/) instance, use the native `ollama` API type rather than the OpenAI-compatible shim — it lets you suppress reasoning tokens and pin the context window directly.
+
+| Setting | Value |
+|---|---|
+| `PBC.APIType` | `ollama` |
+| `PBC.BaseUrl` | `http://127.0.0.1:11434` |
+| `PBC.Model` | `gemma3n:e4b` |
+| `PBC.ApiKey` | (leave empty) |
+| `PBC.Temperature` | `1.0` |
+| `PBC.MaxResponseLength` | `120` |
+| `PBC.OllamaNumCtx` | `32768` |
+| `PBC.MaxHistoryCtx` | `8192` |
+| `PBC.MaxMemoriesCtx` | `8192` |
+| `PBC.OllamaThink` | `0` |
+| `PBC.OllamaKeepAlive` | `-1` |
+
+The Ollama-specific options live in the **OLLAMA OPTIONS** section of the config:
+
+- **`PBC.OllamaThink`** — `0` sends `think:false`, disabling the reasoning output that is the main latency source for local models. Set to `1` only for models that support thinking.
+- **`PBC.OllamaKeepAlive`** — how long the model stays resident after a request. `-1` keeps it loaded indefinitely (pairs well with GPU pinning); leave empty for Ollama's default.
+- **`PBC.OllamaNumCtx`** — pins the request context window (`options.num_ctx`) so local memory use stays bounded. This is the model's full context window — the hard upper bound on the entire prompt (system prompt + character card + memories + history + the current event).
+- **`PBC.MaxResponseLength`** drives `options.num_predict` (output cap), exactly as it does for the other API types.
+
+> [!IMPORTANT]
+> `PBC.OllamaNumCtx` and `PBC.MaxHistoryCtx` must be set together. `OllamaNumCtx` is the model's whole context window; `MaxHistoryCtx` is only the in-prompt **history** budget before condensation triggers, and it shares the window with the system prompt, character card, and memories (`PBC.MaxMemoriesCtx`). Keep `MaxHistoryCtx` at roughly **25%** of `OllamaNumCtx` so the assembled prompt stays comfortably under the window — otherwise history can grow past `num_ctx` and requests fail before condensation ever runs. The example above (`OllamaNumCtx = 32768`, `MaxHistoryCtx = 8192`, `MaxMemoriesCtx = 8192`) follows this rule.
+
+> [!NOTE]
+> The general caveat about locally-run models still applies — as context grows, smaller local models produce lower-quality output than frontier cloud models. The `ollama` type makes local inference viable and predictable, not equivalent to a large cloud model.
+
+For sampling knobs, remember that Ollama only honors them inside the `options` object. Put them in `PBC.OllamaExtraOptions` (e.g. `'top_p':0.9,'repeat_penalty':1.1`), **not** `PBC.ModelExtraParameters` — the latter is merged at the top level of the request body (correct for fields like `format` or `tools`, but ignored by Ollama for sampling parameters).
+
 #### Other Models
 
-Any OpenAI-compatible API should work with `PBC.APIType = openai` — just set `PBC.BaseUrl` to the endpoint (the module appends `/chat/completions` automatically), `PBC.Model` to the model identifier, and `PBC.ApiKey` to your bearer token. If the endpoint doesn't require authentication (e.g. a local Ollama or LM Studio instance), leave `PBC.ApiKey` empty.
+Any OpenAI-compatible API should work with `PBC.APIType = openai` — just set `PBC.BaseUrl` to the endpoint (the module appends `/chat/completions` automatically), `PBC.Model` to the model identifier, and `PBC.ApiKey` to your bearer token. If the endpoint doesn't require authentication (e.g. an LM Studio instance, or Ollama's OpenAI-compatible shim), leave `PBC.ApiKey` empty. For Ollama specifically, prefer the native [`ollama`](#ollama-local) API type over the OpenAI-compatible shim.
 
-Use `PBC.ModelExtraParameters` to inject provider-specific JSON into the request body — this works the same way for both `openai` and `anthropic` API types. Make sure to use parameter names that are valid for your chosen API type (e.g. `top_p` and `top_k` for Anthropic, `frequency_penalty` and `presence_penalty` for OpenAI-compatible providers). Single quotes are used instead of double quotes and are automatically replaced at runtime:
+Use `PBC.ModelExtraParameters` to inject provider-specific JSON into the request body — this works the same way for the `openai`, `anthropic`, and `ollama` API types (for `ollama` it is merged at the top level; use `PBC.OllamaExtraOptions` for sampling knobs). Make sure to use parameter names that are valid for your chosen API type (e.g. `top_p` and `top_k` for Anthropic, `frequency_penalty` and `presence_penalty` for OpenAI-compatible providers). Single quotes are used instead of double quotes and are automatically replaced at runtime:
 
 ```
 PBC.ModelExtraParameters = 'frequency_penalty':0.5,'presence_penalty':0.2
 ```
 
 becomes `"frequency_penalty":0.5,"presence_penalty":0.2` in the request.
+
+Dedicated settings always win over keys in `ModelExtraParameters`: `PBC.Temperature`, `PBC.MaxResponseLength` (and per-call output caps), `PBC.OllamaNumCtx`, `PBC.OllamaThink`, and `PBC.OllamaKeepAlive` are applied first and cannot be overridden from this fragment. Use `ModelExtraParameters` for provider extras only — not to re-set temperature or output limits.
 
 When switching providers, pay attention to `PBC.Temperature` — acceptable ranges vary between models. Check the provider's documentation for the recommended value.
 

--- a/conf/playerbots_characters.conf.dist
+++ b/conf/playerbots_characters.conf.dist
@@ -53,6 +53,13 @@ PBC.DisplayNarratorEvents = 1
 #                  "anthropic"  — Anthropic Messages API /messages endpoint.
 #                                 The module appends /messages to PBC.BaseUrl.
 #                                 Uses x-api-key header and anthropic-version header.
+#                  "ollama"     — Ollama native /api/chat endpoint.
+#                                 The module appends /api/chat to PBC.BaseUrl.
+#                                 Exposes Ollama-specific controls (think, keep_alive,
+#                                 num_ctx, num_predict) via the OLLAMA OPTIONS section
+#                                 below. Recommended for local Ollama instances — it can
+#                                 suppress the reasoning tokens that the OpenAI-compatible
+#                                 shim cannot disable.
 #     Default:     openai
 PBC.APIType = openai
 
@@ -60,6 +67,8 @@ PBC.APIType = openai
 #     Description: The base URL of the LLM API.
 #                  When PBC.APIType = openai:     the module appends /chat/completions to this URL.
 #                  When PBC.APIType = anthropic:  the module appends /messages to this URL.
+#                  When PBC.APIType = ollama:     the module appends /api/chat to this URL
+#                                                 (e.g. http://127.0.0.1:11434).
 #                  REQUIRED. The module will be disabled if missing.
 #     Default:     (empty)
 PBC.BaseUrl =
@@ -104,13 +113,21 @@ PBC.MaxResponseLength = 120
 PBC.Temperature = 1.0
 
 # PBC.ModelExtraParameters
-#     Description: Raw JSON fragment appended to every LLM request body.
-#                  Spliced into the JSON object before the closing '}'.
-#                  Use single quotes instead of double quotes — they are
-#                  automatically replaced with double quotes at runtime.
+#     Description: Raw JSON fragment merged into every LLM request body after the
+#                  core fields are built. Use single quotes instead of double quotes
+#                  — they are automatically replaced with double quotes at runtime.
 #                  Leave empty for no extra parameters.
+#                  Provider-specific extras only (frequency_penalty, thinking, format,
+#                  tools, ...). Does NOT override dedicated settings: PBC.Temperature,
+#                  PBC.MaxResponseLength / per-call output caps, PBC.OllamaNumCtx,
+#                  PBC.OllamaThink, PBC.OllamaKeepAlive, or bounded Ollama options
+#                  (temperature, num_ctx, num_predict). Put Ollama sampling knobs in
+#                  PBC.OllamaExtraOptions instead.
 #     Example (DeepSeek): 'frequency_penalty':0.5,'presence_penalty':0.2
 #     Example (GLM):       'thinking':{'type':'disabled'}
+#     Note (ollama): Top-level fields only (e.g. 'format', 'tools'). Ollama sampling
+#                    knobs (top_p, top_k, repeat_penalty, seed, stop, ...) go in
+#                    PBC.OllamaExtraOptions — Ollama ignores them at the top level.
 #     Default:     (empty)
 PBC.ModelExtraParameters =
 
@@ -130,6 +147,62 @@ PBC.MaxHistoryCtx = 32768
 #                  the budget is increased.
 #     Default:     8192
 PBC.MaxMemoriesCtx = 8192
+
+
+# --------------------------------------------
+# OLLAMA OPTIONS
+# --------------------------------------------
+
+# These settings apply ONLY when PBC.APIType = ollama. They are ignored for the
+# openai and anthropic API types.
+
+# PBC.OllamaThink
+#     Description: Controls Ollama's "think" parameter (reasoning output).
+#                  0 (false) — sends think:false, suppressing the reasoning tokens
+#                              that otherwise add latency. Recommended for chatter.
+#                  1 (true)  — sends think:true; only enable for models that support
+#                              thinking (a non-thinking model may reject the request).
+#     Default:     0 (false)
+PBC.OllamaThink = 0
+
+# PBC.OllamaKeepAlive
+#     Description: How long Ollama keeps the model loaded in memory after a request.
+#                  Accepts a duration string ("5m", "1h") or seconds; "-1" keeps the
+#                  model resident indefinitely (pairs well with GPU pinning / systemd
+#                  keep-alive). Leave empty to use Ollama's own default.
+#     Example:     PBC.OllamaKeepAlive = -1
+#     Default:     (empty)
+PBC.OllamaKeepAlive =
+
+# PBC.OllamaNumCtx
+#     Description: Pins the model's context window (options.num_ctx) for the request.
+#                  Making the context window a hard boundary keeps the local model's
+#                  memory use predictable. 0 = omit (use the model/Modelfile default).
+#                  This is the model's FULL context window — the hard upper bound on the
+#                  entire prompt (system prompt + character card + memories + history +
+#                  current event), not just the history portion.
+#                  IMPORTANT: set this together with PBC.MaxHistoryCtx. MaxHistoryCtx is
+#                  only the in-prompt history budget before condensation triggers, and it
+#                  shares this window with the system prompt, character card, and memories
+#                  (PBC.MaxMemoriesCtx). Keep PBC.MaxHistoryCtx at roughly 25% of
+#                  PBC.OllamaNumCtx so the assembled prompt stays under the window —
+#                  otherwise history can grow past num_ctx and requests fail before
+#                  condensation ever runs.
+#                  Example: OllamaNumCtx = 32768, MaxHistoryCtx = 8192, MaxMemoriesCtx = 8192.
+#     Example:     PBC.OllamaNumCtx = 32768
+#     Default:     0
+PBC.OllamaNumCtx = 0
+
+# PBC.OllamaExtraOptions
+#     Description: Raw JSON fragment merged into the Ollama "options" object — the
+#                  correct place for sampling/runtime knobs (top_p, top_k,
+#                  repeat_penalty, seed, stop, mirostat, ...). Use single quotes
+#                  instead of double quotes; they are replaced automatically at runtime.
+#                  (Output length is controlled by PBC.MaxResponseLength via num_predict,
+#                  and temperature/num_ctx have dedicated settings — no need to set them here.)
+#     Example:     'top_p':0.9,'repeat_penalty':1.1
+#     Default:     (empty)
+PBC.OllamaExtraOptions =
 
 
 # --------------------------------------------
@@ -153,6 +226,13 @@ PBC.AltModel =
 PBC.AltModelMaxResponseLength = 0
 PBC.AltModelTemperature = 1.0
 PBC.AltModelModelExtraParameters =
+
+# Ollama options for the alternative model (used only when PBC.AltModelAPIType = ollama).
+# Same meaning as the OLLAMA OPTIONS section above, applied to the alt model.
+PBC.AltModelOllamaThink = 0
+PBC.AltModelOllamaKeepAlive =
+PBC.AltModelOllamaNumCtx = 0
+PBC.AltModelOllamaExtraOptions =
 
 
 # --------------------------------------------

--- a/src/core/pbc_config.cpp
+++ b/src/core/pbc_config.cpp
@@ -38,6 +38,11 @@ double      g_PBC_Temperature      = 1.0;
 std::string g_PBC_ModelExtraParameters;
 int         g_PBC_RequestTimeoutSec = 30;
 
+bool        g_PBC_OllamaThink       = false;
+std::string g_PBC_OllamaKeepAlive;
+int         g_PBC_OllamaNumCtx      = 0;
+std::string g_PBC_OllamaExtraOptions;
+
 bool        g_PBC_UseAltModelForCondensation      = false;
 bool        g_PBC_UseAltModelForRelationshipUpdate = false;
 std::string g_PBC_AltModelAPIType                  = "openai";
@@ -48,6 +53,11 @@ int         g_PBC_AltModelMaxResponseTokens        = 0;
 double      g_PBC_AltModelTemperature              = 1.0;
 std::string g_PBC_AltModelModelExtraParameters;
 int         g_PBC_AltModelRequestTimeoutSec         = 30;
+
+bool        g_PBC_AltModelOllamaThink               = false;
+std::string g_PBC_AltModelOllamaKeepAlive;
+int         g_PBC_AltModelOllamaNumCtx              = 0;
+std::string g_PBC_AltModelOllamaExtraOptions;
 
 uint32_t    g_PBC_MaxHistoryCtx              = 0;
 uint32_t    g_PBC_MaxMemoriesCtx             = 8192;
@@ -167,6 +177,11 @@ void PBC_LoadConfig(bool /*isStartup*/)
     g_PBC_ModelExtraParameters = sConfigMgr->GetOption<std::string>("PBC.ModelExtraParameters", "");
     g_PBC_RequestTimeoutSec   = sConfigMgr->GetOption<int>("PBC.RequestTimeoutSec", 30);
 
+    g_PBC_OllamaThink         = sConfigMgr->GetOption<bool>("PBC.OllamaThink", false);
+    g_PBC_OllamaKeepAlive     = sConfigMgr->GetOption<std::string>("PBC.OllamaKeepAlive", "");
+    g_PBC_OllamaNumCtx        = sConfigMgr->GetOption<int>("PBC.OllamaNumCtx", 0);
+    g_PBC_OllamaExtraOptions  = sConfigMgr->GetOption<std::string>("PBC.OllamaExtraOptions", "");
+
     // Alt model configuration
     g_PBC_UseAltModelForCondensation      = sConfigMgr->GetOption<bool>("PBC.UseAltModelForCondensation", false);
     g_PBC_UseAltModelForRelationshipUpdate = sConfigMgr->GetOption<bool>("PBC.UseAltModelForRelationshipUpdate", false);
@@ -178,6 +193,11 @@ void PBC_LoadConfig(bool /*isStartup*/)
     g_PBC_AltModelTemperature             = std::round(static_cast<double>(sConfigMgr->GetOption<float>("PBC.AltModelTemperature", 1.0f)) * 100.0) / 100.0;
     g_PBC_AltModelModelExtraParameters    = sConfigMgr->GetOption<std::string>("PBC.AltModelModelExtraParameters", "");
     g_PBC_AltModelRequestTimeoutSec       = sConfigMgr->GetOption<int>("PBC.AltModelRequestTimeoutSec", 30);
+
+    g_PBC_AltModelOllamaThink             = sConfigMgr->GetOption<bool>("PBC.AltModelOllamaThink", false);
+    g_PBC_AltModelOllamaKeepAlive         = sConfigMgr->GetOption<std::string>("PBC.AltModelOllamaKeepAlive", "");
+    g_PBC_AltModelOllamaNumCtx            = sConfigMgr->GetOption<int>("PBC.AltModelOllamaNumCtx", 0);
+    g_PBC_AltModelOllamaExtraOptions      = sConfigMgr->GetOption<std::string>("PBC.AltModelOllamaExtraOptions", "");
 
     g_PBC_MaxHistoryCtx              = sConfigMgr->GetOption<uint32_t>("PBC.MaxHistoryCtx", 0);
     g_PBC_MaxMemoriesCtx             = sConfigMgr->GetOption<uint32_t>("PBC.MaxMemoriesCtx", 8192);
@@ -283,6 +303,11 @@ void PBC_LoadConfig(bool /*isStartup*/)
         "Alt Model: Condensation={} RelationshipUpdate={} APIType='{}' Model='{}' Url='{}' Timeout={}s",
         g_PBC_UseAltModelForCondensation, g_PBC_UseAltModelForRelationshipUpdate,
         g_PBC_AltModelAPIType, g_PBC_AltModel, g_PBC_AltModelBaseUrl, g_PBC_AltModelRequestTimeoutSec);
+
+    PBC_Log(PBC_LogLevel::PBC_DEFAULT,
+        "Ollama Options: Think={} KeepAlive='{}' NumCtx={} (alt: Think={} KeepAlive='{}' NumCtx={})",
+        g_PBC_OllamaThink, g_PBC_OllamaKeepAlive, g_PBC_OllamaNumCtx,
+        g_PBC_AltModelOllamaThink, g_PBC_AltModelOllamaKeepAlive, g_PBC_AltModelOllamaNumCtx);
 }
 
 // Try to read a file into target. Returns true if the file exists and is non-empty.

--- a/src/core/pbc_config.h
+++ b/src/core/pbc_config.h
@@ -33,6 +33,12 @@ extern double      g_PBC_Temperature;
 extern std::string g_PBC_ModelExtraParameters;
 extern int         g_PBC_RequestTimeoutSec;
 
+// Ollama-only options (used when PBC.APIType = ollama)
+extern bool        g_PBC_OllamaThink;
+extern std::string g_PBC_OllamaKeepAlive;
+extern int         g_PBC_OllamaNumCtx;
+extern std::string g_PBC_OllamaExtraOptions;
+
 // Alternative API (for condensation / relationship updates)
 extern bool        g_PBC_UseAltModelForCondensation;
 extern bool        g_PBC_UseAltModelForRelationshipUpdate;
@@ -44,6 +50,12 @@ extern int         g_PBC_AltModelMaxResponseTokens;
 extern double      g_PBC_AltModelTemperature;
 extern std::string g_PBC_AltModelModelExtraParameters;
 extern int         g_PBC_AltModelRequestTimeoutSec;
+
+// Ollama-only options for the alternative model (used when PBC.AltModelAPIType = ollama)
+extern bool        g_PBC_AltModelOllamaThink;
+extern std::string g_PBC_AltModelOllamaKeepAlive;
+extern int         g_PBC_AltModelOllamaNumCtx;
+extern std::string g_PBC_AltModelOllamaExtraOptions;
 
 // Context / condensation
 extern uint32_t    g_PBC_MaxHistoryCtx;

--- a/src/llm/pbc_llm.cpp
+++ b/src/llm/pbc_llm.cpp
@@ -44,6 +44,100 @@ static bool IEquals(const std::string& a, const std::string& b)
     return true;
 }
 
+// Merge PBC.ModelExtraParameters into the request body via JSON parse/update.
+// String-splicing would duplicate keys (e.g. a top-level "options" fragment for
+// Ollama would replace the bounded options object built above).
+//
+// Precedence (intentional): dedicated config keys win over ModelExtraParameters.
+// temperature, max_tokens / num_predict, num_ctx, think, keep_alive, system, and
+// core request shape are set above from PBC.Temperature, PBC.MaxResponseLength,
+// maxTokensOverride, and Ollama-specific settings — they are NOT overridden when
+// the same keys appear in ModelExtraParameters. Use ModelExtraParameters only for
+// provider-specific extras (frequency_penalty, thinking, format, tools, ...).
+static void MergeModelExtraParameters(json& body,
+                                      const std::string& rawExtra,
+                                      bool isOllama,
+                                      bool isAnthropic)
+{
+    if (rawExtra.empty())
+        return;
+
+    std::string extra = rawExtra;
+    std::replace(extra.begin(), extra.end(), '\'', '"');
+    try
+    {
+        json extraJson = json::parse("{" + extra + "}");
+
+        if (isOllama)
+        {
+            // Sampling knobs in ModelExtraParameters belong in options; merge
+            // them there so temperature/num_ctx/num_predict caps are preserved.
+            if (extraJson.contains("options") && extraJson["options"].is_object())
+            {
+                json extraOptions = std::move(extraJson["options"]);
+                extraJson.erase("options");
+
+                if (!body.contains("options") || !body["options"].is_object())
+                    body["options"] = json::object();
+
+                json bounded = json::object();
+                for (const char* key : { "temperature", "num_ctx", "num_predict" })
+                {
+                    if (body["options"].contains(key))
+                        bounded[key] = body["options"][key];
+                }
+
+                body["options"].update(extraOptions);
+                for (auto& [key, val] : bounded.items())
+                    body["options"][key] = val;
+            }
+            else if (extraJson.contains("options"))
+            {
+                PBC_Log(PBC_LogLevel::PBC_WARNING,
+                          "Ollama: PBC.ModelExtraParameters 'options' must be a JSON object; "
+                          "use PBC.OllamaExtraOptions for sampling knobs — ignoring invalid 'options'.");
+                extraJson.erase("options");
+            }
+
+            for (auto& [key, val] : extraJson.items())
+            {
+                // Core request shape and dedicated Ollama settings win.
+                if (key == "model" || key == "messages" || key == "stream")
+                    continue;
+                if (key == "options" && body.contains("options") && body["options"].is_object())
+                    continue;
+                if (key == "think" && body.contains("think"))
+                    continue;
+                if (key == "keep_alive" && body.contains("keep_alive"))
+                    continue;
+                body[key] = val;
+            }
+        }
+        else
+        {
+            for (auto& [key, val] : extraJson.items())
+            {
+                if (key == "model" || key == "messages")
+                    continue;
+                if (isAnthropic && key == "system" && body.contains("system"))
+                    continue;
+                // Intentional: dedicated settings above win — do not let extras override.
+                if (key == "max_tokens" && body.contains("max_tokens"))
+                    continue;
+                if (key == "temperature" && body.contains("temperature"))
+                    continue;
+                body[key] = val;
+            }
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        PBC_Log(PBC_LogLevel::PBC_WARNING,
+                  "Failed to parse ModelExtraParameters ('{}'): {} — ignoring.",
+                  PBC_SanitizeForFmt(rawExtra), ex.what());
+    }
+}
+
 // ---------------------------------------------------------------------------
 // PBC_CallLLMWithConfig  – universal synchronous LLM call
 //   openai:     POST {baseUrl}/chat/completions  (OpenAI-compatible)
@@ -65,12 +159,18 @@ PBC_LLMResult PBC_CallLLMWithConfig(const PBC_APIConfig& cfg,
     PBC_CleanUnknownTokens(usrPrompt);
 
     const bool isAnthropic = IEquals(cfg.apiType, "anthropic");
+    const bool isOllama    = IEquals(cfg.apiType, "ollama");
 
     // --- Build URL --------------------------------------------------------
     std::string url = cfg.baseUrl;
     if (!url.empty() && url.back() == '/')
         url.pop_back();
-    url += isAnthropic ? "/messages" : "/chat/completions";
+    if (isAnthropic)
+        url += "/messages";
+    else if (isOllama)
+        url += "/api/chat";
+    else
+        url += "/chat/completions";
 
     // --- Build request body -----------------------------------------------
     json body;
@@ -104,6 +204,105 @@ PBC_LLMResult PBC_CallLLMWithConfig(const PBC_APIConfig& cfg,
         if (cfg.temperature >= 0.0)
             body["temperature"] = cfg.temperature;
     }
+    else if (isOllama)
+    {
+        // Ollama native /api/chat format.
+        // Messages mirror the OpenAI layout, but runtime/sampling parameters
+        // live in a nested "options" object — top-level copies are ignored by
+        // Ollama. think/keep_alive are genuine top-level fields.
+        json messages = json::array();
+        if (!sysPrompt.empty())
+            messages.push_back({ {"role", "system"}, {"content", sysPrompt} });
+        messages.push_back({ {"role", "user"}, {"content", usrPrompt} });
+        body["messages"] = messages;
+
+        // The single-shot client reads one JSON body; /api/chat defaults to a
+        // streamed NDJSON response, so streaming must be disabled.
+        body["stream"] = false;
+
+        // think:false suppresses reasoning tokens (the latency fix).  Sent in
+        // both states so a thinking model can be explicitly opted in.
+        body["think"] = cfg.ollamaThink;
+
+        // keep_alive keeps the model resident; omitted when unset so Ollama
+        // applies its own default.  Ollama accepts either a JSON number
+        // (seconds; negative = keep loaded indefinitely, 0 = unload now) or a
+        // duration string ("5m", "1h").  A purely numeric value MUST be sent as
+        // a number — as a string ("-1", "300") it has no duration unit and
+        // Ollama rejects it, so it would never keep/unload as intended.
+        if (!cfg.ollamaKeepAlive.empty())
+        {
+            const std::string& ka = cfg.ollamaKeepAlive;
+            const size_t digitsStart = (ka[0] == '-' || ka[0] == '+') ? 1 : 0;
+            const bool isNumeric = digitsStart < ka.size() &&
+                ka.find_first_not_of("0123456789", digitsStart) == std::string::npos;
+            if (isNumeric)
+            {
+                try
+                {
+                    body["keep_alive"] = std::stoll(ka);
+                }
+                catch (const std::exception&)
+                {
+                    body["keep_alive"] = ka; // out-of-range; fall back to string
+                }
+            }
+            else
+            {
+                body["keep_alive"] = ka;
+            }
+        }
+
+        json options = json::object();
+
+        // Merge user-supplied sampling options FIRST (top_p, top_k,
+        // repeat_penalty, seed, stop, ...).  Single quotes are accepted as in
+        // ModelExtraParameters.  These are applied before the dedicated settings
+        // below so that temperature/num_ctx/num_predict — which have their own
+        // config keys and carry the bounding guarantee — always take precedence
+        // and cannot be silently overridden from the extra fragment.
+        if (!cfg.ollamaExtraOptions.empty())
+        {
+            std::string extra = cfg.ollamaExtraOptions;
+            std::replace(extra.begin(), extra.end(), '\'', '"');
+            try
+            {
+                json extraJson = json::parse("{" + extra + "}");
+                options.update(extraJson);
+            }
+            catch (const std::exception& ex)
+            {
+                PBC_Log(PBC_LogLevel::PBC_WARNING,
+                          "Ollama: failed to parse PBC.OllamaExtraOptions ('{}'): {} — ignoring.",
+                          PBC_SanitizeForFmt(cfg.ollamaExtraOptions), ex.what());
+            }
+        }
+
+        if (cfg.temperature >= 0.0)
+            options["temperature"] = cfg.temperature;
+        if (cfg.ollamaNumCtx > 0)
+            options["num_ctx"] = cfg.ollamaNumCtx;
+
+        // num_predict caps generation.  Unlike the OpenAI branch (which omits
+        // max_tokens and lets a cloud model stop on its own), Ollama treats a
+        // missing/negative num_predict as open-ended generation bounded only by
+        // num_ctx — on local hardware that routinely overruns the request
+        // timeout.  So, like the Anthropic branch, num_predict is ALWAYS set:
+        //   -1 → generous bound (4096), >0 → explicit override,
+        //   config value when positive, else the same generous bound (4096).
+        // This guarantees no Ollama request is ever unbounded.
+        if (maxTokensOverride == -1)
+            options["num_predict"] = 4096;
+        else if (maxTokensOverride > 0)
+            options["num_predict"] = maxTokensOverride;
+        else if (cfg.maxResponseTokens > 0)
+            options["num_predict"] = cfg.maxResponseTokens;
+        else
+            options["num_predict"] = 4096;
+
+        if (!options.empty())
+            body["options"] = options;
+    }
     else
     {
         // OpenAI-compatible /chat/completions format
@@ -128,22 +327,9 @@ PBC_LLMResult PBC_CallLLMWithConfig(const PBC_APIConfig& cfg,
         body["messages"] = messages;
     }
 
-    std::string bodyStr = body.dump();
+    MergeModelExtraParameters(body, cfg.modelExtraParameters, isOllama, isAnthropic);
 
-    // Append provider-specific extra parameters from config.
-    // cfg.modelExtraParameters is a raw JSON fragment (key:value pairs) that is
-    // spliced into the request body before the closing '}'.  Single quotes in
-    // the config value are automatically replaced with double quotes, so the
-    // user does not need to escape them.
-    // Example (DeepSeek): 'frequency_penalty':0.5,'presence_penalty':0.2
-    // Example (GLM):       'frequency_penalty':0.5,'thinking':{'type':'disabled'}
-    if (!cfg.modelExtraParameters.empty())
-    {
-        std::string extra = cfg.modelExtraParameters;
-        std::replace(extra.begin(), extra.end(), '\'', '"');
-        bodyStr.pop_back(); // remove trailing '}'
-        bodyStr += "," + extra + "}";
-    }
+    std::string bodyStr = body.dump();
 
     // --- Build headers ----------------------------------------------------
     std::vector<std::pair<std::string, std::string>> headers;
@@ -201,6 +387,8 @@ PBC_LLMResult PBC_CallLLMWithConfig(const PBC_APIConfig& cfg,
                 std::string errMsg;
                 if (resp["error"].is_object() && resp["error"].contains("message"))
                     errMsg = resp["error"]["message"].get<std::string>();
+                else if (resp["error"].is_string())
+                    errMsg = resp["error"].get<std::string>();   // Ollama returns a bare string
                 else
                     errMsg = responseBody;
                 PBC_Log(PBC_LogLevel::PBC_ERROR, "LLM API error (attempt {}/{}): {}",
@@ -228,6 +416,22 @@ PBC_LLMResult PBC_CallLLMWithConfig(const PBC_APIConfig& cfg,
                     int outputTokens = resp["usage"].value("output_tokens", 0);
                     tokensUsed = inputTokens + outputTokens;
                 }
+            }
+            else if (isOllama)
+            {
+                // Ollama response: message.content (must be a string; null/missing is invalid)
+                const json& msg = resp["message"];
+                if (!msg.is_object() || !msg.contains("content") || !msg["content"].is_string())
+                {
+                    PBC_Log(PBC_LogLevel::PBC_ERROR, "LLM: unexpected Ollama response format (attempt {}/{}).", attempt, MAX_ATTEMPTS);
+                    continue;
+                }
+                text = msg["content"].get<std::string>();
+
+                // Usage: prompt_eval_count (prompt) + eval_count (completion)
+                int promptTokens = resp.value("prompt_eval_count", 0);
+                int evalTokens   = resp.value("eval_count", 0);
+                tokensUsed = promptTokens + evalTokens;
             }
             else
             {
@@ -284,6 +488,10 @@ PBC_LLMResult PBC_CallLLM(const std::string& systemPrompt,
     cfg.temperature          = g_PBC_Temperature;
     cfg.modelExtraParameters = g_PBC_ModelExtraParameters;
     cfg.requestTimeoutSec    = g_PBC_RequestTimeoutSec;
+    cfg.ollamaThink          = g_PBC_OllamaThink;
+    cfg.ollamaKeepAlive      = g_PBC_OllamaKeepAlive;
+    cfg.ollamaNumCtx         = g_PBC_OllamaNumCtx;
+    cfg.ollamaExtraOptions   = g_PBC_OllamaExtraOptions;
     return PBC_CallLLMWithConfig(cfg, systemPrompt, userPrompt, maxTokensOverride, preserveNewlines);
 }
 
@@ -301,5 +509,9 @@ PBC_LLMResult PBC_CallLLMAlt(const std::string& systemPrompt,
     cfg.temperature          = g_PBC_AltModelTemperature;
     cfg.modelExtraParameters = g_PBC_AltModelModelExtraParameters;
     cfg.requestTimeoutSec    = g_PBC_AltModelRequestTimeoutSec;
+    cfg.ollamaThink          = g_PBC_AltModelOllamaThink;
+    cfg.ollamaKeepAlive      = g_PBC_AltModelOllamaKeepAlive;
+    cfg.ollamaNumCtx         = g_PBC_AltModelOllamaNumCtx;
+    cfg.ollamaExtraOptions   = g_PBC_AltModelOllamaExtraOptions;
     return PBC_CallLLMWithConfig(cfg, systemPrompt, userPrompt, maxTokensOverride, preserveNewlines);
 }

--- a/src/llm/pbc_llm.h
+++ b/src/llm/pbc_llm.h
@@ -18,14 +18,20 @@ struct PBC_LLMResult
 // ---------------------------------------------------------------------------
 struct PBC_APIConfig
 {
-    std::string apiType;            // "openai" or "anthropic"
+    std::string apiType;            // "openai", "anthropic" or "ollama"
     std::string baseUrl;            // e.g. https://api.deepseek.com/v1
     std::string apiKey;             // Bearer token / x-api-key (empty = no auth header)
     std::string model;              // model identifier
     int         maxResponseTokens;  // 0 = unlimited / omit
     double      temperature;        // sampling temperature
-    std::string modelExtraParameters; // raw JSON merged into request body
+    std::string modelExtraParameters; // raw JSON merged into request body (top level)
     int         requestTimeoutSec;  // HTTP timeout
+
+    // --- Ollama-only (apiType == "ollama") ---------------------------------
+    bool        ollamaThink        = false; // false → send think:false (suppress reasoning)
+    std::string ollamaKeepAlive;            // keep_alive value (empty = omit, use Ollama default)
+    int         ollamaNumCtx       = 0;     // options.num_ctx (0 = omit)
+    std::string ollamaExtraOptions;         // raw JSON merged into the options object
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a native Ollama provider as a third `PBC.APIType` (`ollama`), calling Ollama's `/api/chat` endpoint directly instead of going through the OpenAI-compatible shim. This exposes Ollama-specific controls the shim hides — most importantly `think:false`, which suppresses the reasoning tokens that are the main latency source for local models.

## Changes

- **New API type `ollama`** in `PBC_CallLLMWithConfig` — appends `/api/chat`, sends `stream:false` (required for the single-shot client), top-level `think` and optional `keep_alive`, and a nested `options` object (`temperature`, `num_ctx`, `num_predict`). Response is read from `message.content`; token usage from `prompt_eval_count + eval_count`. Error parsing now also handles Ollama's bare-string `error` field.
- **`num_predict`** reuses the existing `PBC.MaxResponseLength` / `maxTokensOverride` semantics (`-1` omits the cap), consistent with the other providers.
- **New config keys** (main + alt-model parity): `PBC.OllamaThink`, `PBC.OllamaKeepAlive`, `PBC.OllamaNumCtx`, `PBC.OllamaExtraOptions` (and the `PBC.AltModelOllama*` equivalents). Each is omitted from the request when left at its default so Ollama applies its own defaults.
- **`PBC.OllamaExtraOptions`** merges into the `options` object (the correct place for sampling knobs like `top_p`, `top_k`, `repeat_penalty`), while the existing `PBC.ModelExtraParameters` continues to splice at the top level (for fields like `format`/`tools`) — Ollama ignores sampling params placed at the top level.
- **Docs**: `conf/playerbots_characters.conf.dist` gains an OLLAMA OPTIONS section and alt-model keys; `README.md` adds `ollama` to the provider list plus an Ollama (local) config example and the `ExtraOptions` vs `ExtraParameters` guidance.

## Notes

- `.chars api-test` and `.chars alt-api-test` route through the same call path, so they validate the new provider with no extra code.
- `PBC.OllamaThink = 1` should only be used with models that support thinking; some Ollama versions reject `think` on non-thinking models. Default `0` (sends `think:false`) is the intended path.
- `PBC.OllamaNumCtx` is the model's request context window and is intentionally separate from `PBC.MaxHistoryCtx` (the in-prompt history condensation budget).